### PR TITLE
Update arg parser, fix deprecated JSKit types

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser", from: "0.0.1"),
-        .package(name: "swift-format", url: "https://github.com/apple/swift-format.git", .branch("swift-5.2-branch")),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("swift-5.2-branch")),
+        .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser", from: "0.3.1"),
+        .package(name: "swift-format", url: "https://github.com/apple/swift-format.git", .branch("swift-5.3-branch")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .upToNextMinor(from: "0.50300.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Commands/GenerateCode.swift
+++ b/Sources/Commands/GenerateCode.swift
@@ -19,19 +19,19 @@ public struct GenerateCode: ParsableCommand {
 
     /// The path to the output directory.
     @Option(name: .shortAndLong, help: "The path to the output directory.")
-    public var ouputDirectory: String
+    public var outputDirectory: String
 
     /// Create a file for each definition.
-    @Flag(name: .long, default: true, inversion: .prefixedNo, help: "Create a file for each definition.")
-    public var createSeparateFiles: Bool
+    @Flag(name: .long, inversion: .prefixedNo, help: "Create a file for each definition.")
+    public var createSeparateFiles: Bool = true
 
     /// Print verbose output.
     @Flag(help: "Print verbose output.")
-    public var verbose: Bool
+    public var verbose: Bool = false
 
     /// Run swift-format over output.
-    @Flag(name: .long, default: true, inversion: .prefixedNo, help: "Run swift-format over output.")
-    public var prettyPrint: Bool
+    @Flag(name: .long, inversion: .prefixedNo, help: "Run swift-format over output.")
+    public var prettyPrint: Bool = true
 
     /// Initialize a `GenerateCode` instance
     public init() {}
@@ -42,7 +42,7 @@ public struct GenerateCode: ParsableCommand {
 
         if verbose {
             print("inputDirectory: \(inputDirectory)")
-            print("ouputDirectory: \(ouputDirectory)")
+            print("outputDirectory: \(outputDirectory)")
             print("createSeparateFiles: \(createSeparateFiles)")
         }
 
@@ -50,6 +50,7 @@ public struct GenerateCode: ParsableCommand {
             print("Error tokenizing input files.")
             Self.exit(withError: ExitCode.failure)
         }
+        print("files tokenized successfully")
 
         let parser = Parser(input: tokenisationResult)
         let definitions: [Definition]
@@ -89,8 +90,8 @@ public struct GenerateCode: ParsableCommand {
 
         """
 
-        let packageDirectory = URL(fileURLWithPath: ouputDirectory).appendingPathComponent("WebAPI")
-        let sourcesDirectory = packageDirectory.appendingPathComponent("Sources").appendingPathComponent("WebAPI")
+        let packageDirectory = URL(fileURLWithPath: outputDirectory).appendingPathComponent("WebIDL")
+        let sourcesDirectory = packageDirectory.appendingPathComponent("Sources").appendingPathComponent("WebIDL")
 
         let fileManager = FileManager.default
 

--- a/Sources/WebIDL/IntermediateRepresentation/IRGenerator.swift
+++ b/Sources/WebIDL/IntermediateRepresentation/IRGenerator.swift
@@ -289,7 +289,7 @@ public class IRGenerator {
 
         case .promiseType(let promise):
             let returnType = handleType(promise.returnType)
-            return ir.registerBasicType(withTypeName: "Promise<\(returnType.identifier)>")
+            return ir.registerBasicType(withTypeName: "JSPromise<\(returnType.identifier), JSError>")
         }
     }
 

--- a/Sources/WebIDL/IntermediateRepresentation/Type Nodes/DictionaryNode.swift
+++ b/Sources/WebIDL/IntermediateRepresentation/Type Nodes/DictionaryNode.swift
@@ -70,11 +70,11 @@ class DictionaryNode: TypeNode, Equatable {
 
             private let dictionary: [String : JSValue]
 
-            public init(uniqueKeysWithValues elements: [(Key, JSValueConvertible)]) {
+            public init(uniqueKeysWithValues elements: [(Key, ConvertibleToJSValue)]) {
                 self.dictionary = Dictionary(uniqueKeysWithValues: elements.map({ ($0.0.rawValue, $0.1.jsValue()) }))
             }
 
-            public init(dictionaryLiteral elements: (Key, JSValueConvertible)...) {
+            public init(dictionaryLiteral elements: (Key, ConvertibleToJSValue)...) {
                 self.dictionary = Dictionary(uniqueKeysWithValues: elements.map({ ($0.0.rawValue, $0.1.jsValue()) }))
             }
 

--- a/Sources/WebIDL/IntermediateRepresentation/Type Nodes/EnumerationWithRawValueNode.swift
+++ b/Sources/WebIDL/IntermediateRepresentation/Type Nodes/EnumerationWithRawValueNode.swift
@@ -35,7 +35,7 @@ class EnumerationWithRawValueNode: TypeNode, Equatable {
         }
 
         var declaration = """
-        public enum \(typeName): String, JSValueCodable {
+        public enum \(typeName): String, JSValueCompatible {
 
             public static func construct(from jsValue: JSValue) -> \(typeName)? {
                 if let string = jsValue.string,


### PR DESCRIPTION
This makes the output fully compatible with JavaScriptKit 0.9. I've also updated dependencies in `Package.swift` to use their latest stable versions.