### PR TITLE
Add source range information to tokenizer output

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        swift-version: "5.2.0"
-    - name: Xcode 11.5
-      run: sudo xcode-select -s /Applications/Xcode_11.5.app/Contents/Developer
+        swift-version: "5.3.0"
+    - name: Xcode 12.3
+      run: sudo xcode-select -s /Applications/Xcode_12.3.app/Contents/Developer
     - name: Xcode version check
       run: xcodebuild -version
     - name: Check version

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,11 +2,20 @@
   "object": {
     "pins": [
       {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
+        }
+      },
+      {
         "package": "swift-format",
         "repositoryURL": "https://github.com/apple/swift-format.git",
         "state": {
-          "branch": "swift-5.2-branch",
-          "revision": "f22aade8a6ee061b4a7041601ededd8ad7bc2122",
+          "branch": "swift-5.3-branch",
+          "revision": "12089179aa1668a2478b2b2111d98fa37f3531e3",
           "version": null
         }
       },
@@ -14,9 +23,9 @@
         "package": "SwiftSyntax",
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
-          "branch": "swift-5.2-branch",
-          "revision": "0688b9cfc4c3dd234e4f55f1f056b2affc849873",
-          "version": null
+          "branch": null,
+          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
+          "version": "0.50300.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,9 @@ let package = Package(
         ),
         .target(
             name: "WebIDL",
-            dependencies: [],
+            dependencies: [
+                "SwiftSyntax"
+            ],
             path: "Sources/WebIDL"
         ),
         .target(
@@ -43,7 +45,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "SwiftFormat", package: "swift-format"),
-                .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+                "SwiftSyntax",
                 .target(name: "WebIDL"),
             ],
             // Ran into linker issues: GenerateCode was not usable in tests when it is declared in webidl2swift

--- a/Sources/Commands/GenerateCode.swift
+++ b/Sources/Commands/GenerateCode.swift
@@ -46,20 +46,22 @@ public struct GenerateCode: ParsableCommand {
             print("createSeparateFiles: \(createSeparateFiles)")
         }
 
-        guard let tokenisationResult = try Tokenizer.tokenize(filesInDirectoryAt: URL(fileURLWithPath: inputDirectory)) else {
+        guard let TokenizationResult = try Tokenizer.tokenize(filesInDirectoryAt: URL(fileURLWithPath: inputDirectory)) else {
             print("Error tokenizing input files.")
             Self.exit(withError: ExitCode.failure)
         }
         print("files tokenized successfully")
 
-        let parser = Parser(input: tokenisationResult)
+        let parser = Parser(input: TokenizationResult)
         let definitions: [Definition]
         do {
             definitions = try parser.parse()
         } catch let error as Parser.Error {
-            print(error.localizedDescription)
+            print("Parser error")
+            print(error.description)
             Self.exit(withError: ExitCode.failure)
         } catch {
+            print("unknown error")
             throw error
         }
 

--- a/Sources/Commands/GenerateCode.swift
+++ b/Sources/Commands/GenerateCode.swift
@@ -46,13 +46,13 @@ public struct GenerateCode: ParsableCommand {
             print("createSeparateFiles: \(createSeparateFiles)")
         }
 
-        guard let TokenizationResult = try Tokenizer.tokenize(filesInDirectoryAt: URL(fileURLWithPath: inputDirectory)) else {
+        guard let tokenizationResult = try Tokenizer.tokenize(filesInDirectoryAt: URL(fileURLWithPath: inputDirectory)) else {
             print("Error tokenizing input files.")
             Self.exit(withError: ExitCode.failure)
         }
         print("files tokenized successfully")
 
-        let parser = Parser(input: TokenizationResult)
+        let parser = Parser(input: tokenizationResult)
         let definitions: [Definition]
         do {
             definitions = try parser.parse()

--- a/Sources/WebIDL/Tokenizer/Token.swift
+++ b/Sources/WebIDL/Tokenizer/Token.swift
@@ -3,38 +3,74 @@
 //
 
 import Foundation
+import SwiftSyntax
 
-public enum Token: Equatable, Hashable, CustomStringConvertible {
+extension SourceLocation: Equatable {
+    public static func ==(left: Self, right: Self) -> Bool {
+        return left.offset == right.offset &&
+            left.column == right.column &&
+            left.line == right.line &&
+            left.file == right.file
+    }
+}
 
-    case terminal(Terminal)
+extension SourceLocation: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(offset)
+        hasher.combine(column)
+        hasher.combine(line)
+        hasher.combine(file)
+    }
+}
 
-    case integer                    //  =   /-?([1-9][0-9]*|0[Xx][0-9A-Fa-f]+|0[0-7]*)/
-    case decimal                    //  =   /-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+)/
-    case identifier                 //  =   /[_-]?[A-Za-z][0-9A-Z_a-z-]*/
-    case string                     //  =   /"[^"]*"/
-    case other                      //  =   /[^\t\n\r 0-9A-Za-z]/
-    case comment(String)
-    case multilineComment(String)
+extension SourceRange: Equatable {
+    public static func ==(left: Self, right: Self) -> Bool {
+        return left.start == right.start && left.end == right.end
+    }
+}
 
-    public var description: String {
+extension SourceRange: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(start)
+        hasher.combine(end)
+    }
+}
 
-        switch self {
-        case .terminal(let terminal):
-            return ".terminal(\(terminal.description))"
-        case .integer:
-            return ".integer"
-        case .decimal:
-            return ".decimal"
-        case .identifier:
-            return ".identifer"
-        case .string:
-            return ".string"
-        case .other:
-            return ".other"
-        case .comment:
-            return ".comment"
-        case .multilineComment:
-            return ".multilineComment"
+public struct Token: Hashable {
+    let kind: Kind
+    let range: SourceRange
+
+    public enum Kind: Hashable, CustomStringConvertible {
+        case terminal(Terminal)
+
+        case integer                    //  =   /-?([1-9][0-9]*|0[Xx][0-9A-Fa-f]+|0[0-7]*)/
+        case decimal                    //  =   /-?(([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+)/
+        case identifier                 //  =   /[_-]?[A-Za-z][0-9A-Z_a-z-]*/
+        case string                     //  =   /"[^"]*"/
+        case other                      //  =   /[^\t\n\r 0-9A-Za-z]/
+        case comment(String)
+        case multilineComment(String)
+
+        public var description: String {
+
+            switch self {
+            case .terminal(let terminal):
+                return ".terminal(\(terminal.description))"
+            case .integer:
+                return ".integer"
+            case .decimal:
+                return ".decimal"
+            case .identifier:
+                return ".identifer"
+            case .string:
+                return ".string"
+            case .other:
+                return ".other"
+            case .comment:
+                return ".comment"
+            case .multilineComment:
+                return ".multilineComment"
+            }
         }
     }
 }

--- a/Sources/WebIDL/Tokenizer/Tokenizer.swift
+++ b/Sources/WebIDL/Tokenizer/Tokenizer.swift
@@ -2,6 +2,8 @@
 //  Created by Manuel Burghard. Licensed unter MIT.
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 import SwiftSyntax
 

--- a/Sources/WebIDL/Tokenizer/Tokenizer.swift
+++ b/Sources/WebIDL/Tokenizer/Tokenizer.swift
@@ -3,11 +3,12 @@
 //
 
 import Foundation
+import SwiftSyntax
 
 ///
 public typealias Tokens = [Token]
 
-public struct TokenisationResult: CustomStringConvertible {
+public struct TokenizationResult: CustomStringConvertible {
 
     public let tokens: Tokens
     public let identifiers: [String]
@@ -16,9 +17,9 @@ public struct TokenisationResult: CustomStringConvertible {
     public let strings: [String]
     public let others: [String]
 
-    func merging(_ other: TokenisationResult) -> TokenisationResult {
+    func merging(_ other: TokenizationResult) -> TokenizationResult {
 
-        TokenisationResult(tokens: tokens + other.tokens,
+        TokenizationResult(tokens: tokens + other.tokens,
                            identifiers: identifiers + other.identifiers,
                            integers: integers + other.integers,
                            decimals: decimals + other.decimals,
@@ -39,7 +40,7 @@ public struct TokenisationResult: CustomStringConvertible {
         var iterator = tokens.makeIterator()
         while let token = iterator.next() {
 
-            switch token {
+            switch token.kind {
             case .terminal(.closingSquareBracket): stringValues.append("]\n")
             case .terminal(.openingCurlyBraces): stringValues.append("{\n")
             case .terminal(.semicolon): stringValues.append(";\n")
@@ -83,47 +84,51 @@ public enum Tokenizer {
     /// Tokenize all `.webidl` files in the given directory
     /// - Parameter directoryURL: An URL to a directory that contains `.webidl` files
     /// - Throws: Any error related to the file operations or the tokenization operation.
-    /// - Returns: A `TokenisationResult` instance containing the token stream for the given files.
-    public static func tokenize(filesInDirectoryAt directoryURL: URL) throws -> TokenisationResult? {
+    /// - Returns: A `TokenizationResult` instance containing the token stream for the given files.
+    public static func tokenize(filesInDirectoryAt directoryURL: URL) throws -> TokenizationResult? {
 
-        var tokenisationResult = TokenisationResult(tokens: [], identifiers: [], integers: [], decimals: [], strings: [], others: [])
+        var tokenizationResult = TokenizationResult(tokens: [], identifiers: [], integers: [], decimals: [], strings: [], others: [])
         let files = try FileManager.default.contentsOfDirectory(at: directoryURL,
                                                                 includingPropertiesForKeys: nil,
                                                                 options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants, .skipsPackageDescendants])
-        for file in files where file.pathExtension == "webidl" {
+        for file in files where file.pathExtension == "idl" {
 
             guard let result = try Tokenizer.tokenize(fileAt: file) else {
                 continue
             }
-            tokenisationResult = tokenisationResult.merging(result)
+            tokenizationResult = tokenizationResult.merging(result)
         }
-        return tokenisationResult
+        return tokenizationResult
     }
 
     /// Tokenize a single Web IDL file
     /// - Parameter fileURL: An URL to a file containing Web IDL definitions.
     /// - Throws: Any error related to the file operations or the tokenization operation.
-    /// - Returns: A `TokenisationResult` instance containing the token stream for the given file.
-    public static func tokenize(fileAt fileURL: URL) throws -> TokenisationResult? {
+    /// - Returns: A `TokenizationResult` instance containing the token stream for the given file.
+    public static func tokenize(fileAt fileURL: URL) throws -> TokenizationResult? {
 
         let fileData = try Data(contentsOf: fileURL)
         guard let string = String(data: fileData, encoding: .utf8) else {
             return nil
         }
-        return try tokenize(string, name: fileURL.lastPathComponent)
+        return try tokenize(string, filePath: fileURL.path)
     }
 
     // swiftlint:disable cyclomatic_complexity function_body_length
     /// Tokenize Web IDL definitions
     /// - Parameter string: A string containing Web IDL definitions.
+    /// - Parameter filePath: A path to the file containing Web IDL definitions.
     /// - Throws: Any error related to the file operations or the tokenization operation.
-    /// - Returns: A `TokenisationResult` instance containing the token stream for the given file.
-    public static func tokenize(_ string: String, name: String = "<unknown>") throws -> TokenisationResult {
+    /// - Returns: A `TokenizationResult` instance containing the token stream for the given file.
+    public static func tokenize(_ string: String, filePath: String = "<unknown>") throws -> TokenizationResult {
 
         var tokens = Tokens()
 
         var state = State.regular
         var buffer = ""
+        var tokenStartOffset = 0
+        var currentIndex = string.utf8.startIndex
+        var currentOffset = 0
 
         func reset() {
             state = .regular
@@ -136,12 +141,26 @@ public enum Tokenizer {
         var strings: [String] = []
         var others: [String] = []
 
+        func currentRange() -> SourceRange {
+            let converter = SourceLocationConverter(file: filePath, source: string)
+
+            return .init(
+                start: .init(offset: tokenStartOffset, converter: converter),
+                end: .init(offset: currentOffset, converter: converter)
+            )
+        }
+
+        func appendToken(_ kind: Token.Kind) {
+            tokens.append(.init(kind: kind, range: currentRange()))
+            tokenStartOffset = currentOffset + 1
+        }
+
         func appendIntegerLiteral() {
             defer { reset() }
             guard let integer = Int(buffer) else {
                 return
             }
-            tokens.append(.integer)
+            appendToken(.integer)
             integers.append(integer)
         }
 
@@ -150,7 +169,7 @@ public enum Tokenizer {
             guard let integer = Int(buffer, radix: 16) else {
                 return
             }
-            tokens.append(.integer)
+            appendToken(.integer)
             integers.append(integer)
         }
 
@@ -159,138 +178,145 @@ public enum Tokenizer {
             guard let double = Double(buffer) else {
                 return
             }
-            tokens.append(.decimal)
+            appendToken(.decimal)
             decimals.append(double)
         }
 
         func appendIdentifier() {
             if let symbol = Terminal(rawValue: buffer) {
-                tokens.append(.terminal(symbol))
+                appendToken(.terminal(symbol))
             } else if identifierRegex.match(buffer) {
-                tokens.append(.identifier)
+                appendToken(.identifier)
                 identifiers.append(buffer)
             } else if integerRegex.match(buffer), let integer = Int(buffer) ?? Int(buffer, radix: 16) {
-                tokens.append(.integer)
+                appendToken(.integer)
                 integers.append(integer)
             } else if decimalRegex.match(buffer), let double = Double(buffer) {
-                tokens.append(.decimal)
+                appendToken(.decimal)
                 decimals.append(double)
             } else if otherRegex.match(buffer) {
-                tokens.append(.other)
+                appendToken(.other)
                 others.append(buffer)
             } else {
-                print("[\(name)] Undefined sequence: \(buffer)")
+                print("[\(filePath):\(currentRange())] Undefined sequence: \(buffer)")
             }
             reset()
         }
 
-        for character in string {
+        while currentIndex < string.utf8.endIndex, let character = String(
+                decoding: [string.utf8[currentIndex]],
+                as: UTF8.self
+        ).first {
+            defer {
+                currentOffset += 1
+                currentIndex = string.utf8.index(after: currentIndex)
+            }
 
             switch (state, character) {
             case (.identifier, "["):
                 appendIdentifier()
-                tokens.append(.terminal(.openingSquareBracket))
+                appendToken(.terminal(.openingSquareBracket))
 
             case (.regular, "["):
-                tokens.append(.terminal(.openingSquareBracket))
+                appendToken(.terminal(.openingSquareBracket))
 
             case (.identifier, "]"):
                 appendIdentifier()
                 fallthrough
 
             case (.regular, "]"):
-                tokens.append(.terminal(.closingSquareBracket))
+                appendToken(.terminal(.closingSquareBracket))
 
             case (.identifier, "("):
                 appendIdentifier()
                 fallthrough
 
             case (.regular, "("):
-                tokens.append(.terminal(.openingParenthesis))
+                appendToken(.terminal(.openingParenthesis))
 
             case (.identifier, ")"):
                 appendIdentifier()
-                tokens.append(.terminal(.closingParenthesis))
+                appendToken(.terminal(.closingParenthesis))
 
             case (.integerLiteral, ")"):
                 appendIntegerLiteral()
-                tokens.append(.terminal(.closingParenthesis))
+                appendToken(.terminal(.closingParenthesis))
 
             case (.hexLiteral, ")"):
                 appendHexLiteral()
-                tokens.append(.terminal(.closingParenthesis))
+                appendToken(.terminal(.closingParenthesis))
 
             case (.regular, ")"):
-                tokens.append(.terminal(.closingParenthesis))
+                appendToken(.terminal(.closingParenthesis))
 
             case (.identifier, "<"):
                 appendIdentifier()
-                tokens.append(.terminal(.openingAngleBracket))
+                appendToken(.terminal(.openingAngleBracket))
 
             case (.regular, "<"):
-                tokens.append(.terminal(.openingAngleBracket))
+                appendToken(.terminal(.openingAngleBracket))
 
             case (.identifier, ">"):
                 appendIdentifier()
-                tokens.append(.terminal(.closingAngleBracket))
+                appendToken(.terminal(.closingAngleBracket))
 
             case (.regular, ">"):
-                tokens.append(.terminal(.closingAngleBracket))
+                appendToken(.terminal(.closingAngleBracket))
 
             case (.identifier, "{"):
                 appendIdentifier()
-                tokens.append(.terminal(.openingCurlyBraces))
+                appendToken(.terminal(.openingCurlyBraces))
 
             case (.regular, "{"):
-                tokens.append(.terminal(.openingCurlyBraces))
+                appendToken(.terminal(.openingCurlyBraces))
 
             case (.identifier, "}"):
                 appendIdentifier()
-                tokens.append(.terminal(.closingCurlyBraces))
+                appendToken(.terminal(.closingCurlyBraces))
 
             case (.regular, "}"):
-                tokens.append(.terminal(.closingCurlyBraces))
+                appendToken(.terminal(.closingCurlyBraces))
 
             case (.identifier, "?"):
                 appendIdentifier()
-                tokens.append(.terminal(.questionMark))
+                appendToken(.terminal(.questionMark))
 
             case (.regular, "?"):
-                tokens.append(.terminal(.questionMark))
+                appendToken(.terminal(.questionMark))
 
             case (.identifier, "="):
                 appendIdentifier()
-                tokens.append(.terminal(.equalSign))
+                appendToken(.terminal(.equalSign))
 
             case (.regular, "="):
-                tokens.append(.terminal(.equalSign))
+                appendToken(.terminal(.equalSign))
 
             case (.identifier, ","):
                 appendIdentifier()
-                tokens.append(.terminal(.comma))
+                appendToken(.terminal(.comma))
 
             case (.integerLiteral, ","):
                 appendIntegerLiteral()
-                tokens.append(.terminal(.comma))
+                appendToken(.terminal(.comma))
 
             case (.hexLiteral, ","):
                 appendHexLiteral()
-                tokens.append(.terminal(.comma))
+                appendToken(.terminal(.comma))
 
             case (.decimalLiteral, ","):
                 appendDecimalLiteral()
-                tokens.append(.terminal(.comma))
+                appendToken(.terminal(.comma))
 
             case (.regular, ","):
-                tokens.append(.terminal(.comma))
+                appendToken(.terminal(.comma))
 
             case (.identifier, ";"):
                 appendIdentifier()
-                tokens.append(.terminal(.semicolon))
+                appendToken(.terminal(.semicolon))
 
             case (.integerLiteral, ";"):
                 appendIntegerLiteral()
-                tokens.append(.terminal(.semicolon))
+                appendToken(.terminal(.semicolon))
 
             case (.integerLiteral, "."):
                 state = .decimalLiteral
@@ -298,25 +324,25 @@ public enum Tokenizer {
 
             case (.hexLiteral, ";"):
                 appendHexLiteral()
-                tokens.append(.terminal(.semicolon))
+                appendToken(.terminal(.semicolon))
 
             case (.decimalLiteral, ";"):
                 appendDecimalLiteral()
-                tokens.append(.terminal(.semicolon))
+                appendToken(.terminal(.semicolon))
 
             case (.regular, ";"):
-                tokens.append(.terminal(.semicolon))
+                appendToken(.terminal(.semicolon))
 
             case (.identifier, ":"):
                 appendIdentifier()
-                tokens.append(.terminal(.colon))
+                appendToken(.terminal(.colon))
 
             case (.identifier, "."):
                 appendIdentifier()
                 state = .startOfEllipsis
 
             case (.regular, ":"):
-                tokens.append(.terminal(.colon))
+                appendToken(.terminal(.colon))
 
             case (.regular, "."):
                 state = .startOfEllipsis
@@ -325,16 +351,16 @@ public enum Tokenizer {
                 state = .ellipsis
 
             case (.startOfEllipsis, let char) where char.isWhitespace || char.isNewline:
-                tokens.append(.terminal(.dot))
+                appendToken(.terminal(.dot))
                 reset()
 
             case (.ellipsis, "."):
-                tokens.append(.terminal(.ellipsis))
+                appendToken(.terminal(.ellipsis))
                 reset()
 
             case (.ellipsis, let char) where char.isWhitespace || char.isNewline:
-                tokens.append(.terminal(.dot))
-                tokens.append(.terminal(.dot))
+                appendToken(.terminal(.dot))
+                appendToken(.terminal(.dot))
                 reset()
 
             case (.integerLiteral, let char) where buffer.count == 1 && char.lowercased() == "x":
@@ -384,7 +410,7 @@ public enum Tokenizer {
             case (.comment, let char):
                 if buffer.isEmpty, char.isWhitespace { continue }
                 if char.isNewline {
-                    tokens.append(.comment(buffer))
+                    appendToken(.comment(buffer))
                     reset()
                     continue
                 }
@@ -398,7 +424,7 @@ public enum Tokenizer {
                 state = .maybeEndOfMultilineComment
 
             case (.maybeEndOfMultilineComment, "/"):
-                tokens.append(.multilineComment(buffer))
+                appendToken(.multilineComment(buffer))
                 reset()
 
             case (.maybeEndOfMultilineComment, "*"):
@@ -433,7 +459,7 @@ public enum Tokenizer {
                 state = .stringLiteral
 
             case (.stringLiteral, "\""):
-                tokens.append(.string)
+                appendToken(.string)
                 strings.append(buffer)
                 reset()
 
@@ -441,6 +467,7 @@ public enum Tokenizer {
                 buffer.append(char)
 
             default:
+                tokenStartOffset += 1
                 continue
             }
         }
@@ -461,18 +488,19 @@ public enum Tokenizer {
         case .escapedChar:
             break
         case .comment:
-            tokens.append(.comment(buffer))
+            appendToken(.comment(buffer))
         case .multilineComment:
-            tokens.append(.multilineComment(buffer))
+            appendToken(.multilineComment(buffer))
         case .startOfComment, .maybeEndOfMultilineComment:
             fatalError("Unterminated start of comment")
         case .startOfEllipsis:
-            tokens.append(.terminal(.dot))
+            appendToken(.terminal(.dot))
         case .ellipsis:
-            tokens.append(contentsOf: [.terminal(.dot), .terminal(.dot)])
+            appendToken(.terminal(.dot))
+            appendToken(.terminal(.dot))
         }
 
-        return TokenisationResult(tokens: tokens, identifiers: identifiers, integers: integers, decimals: decimals, strings: strings, others: others)
+        return TokenizationResult(tokens: tokens, identifiers: identifiers, integers: integers, decimals: decimals, strings: strings, others: others)
     }
     // swiftlint:enable cyclomatic_complexity function_body_length
 }

--- a/Sources/WebIDL/Tokenizer/Tokenizer.swift
+++ b/Sources/WebIDL/Tokenizer/Tokenizer.swift
@@ -208,7 +208,9 @@ public enum Tokenizer {
                 as: UTF8.self
         ).first {
             defer {
-                currentOffset += 1
+                if currentOffset < string.utf8.count - 1 {
+                    currentOffset += 1
+                }
                 currentIndex = string.utf8.index(after: currentIndex)
             }
 

--- a/Tests/webidl2swiftTests/TokenizerTests.swift
+++ b/Tests/webidl2swiftTests/TokenizerTests.swift
@@ -8,105 +8,126 @@ import XCTest
 final class TokenizerTests: XCTestCase {
 
     func test_ellipsis() throws {
-
-        XCTAssertEqual(try Tokenizer.tokenize("...").tokens, [.terminal(.ellipsis)])
-        XCTAssertEqual(try Tokenizer.tokenize(" ... ").tokens, [.terminal(.ellipsis)])
+        XCTAssertEqual(
+            try Tokenizer.tokenize("...").tokens,
+            [
+                .init(
+                    kind: .terminal(.ellipsis),
+                    range: .init(
+                        start: .init(line: 1, column: 1, offset: 0, file: "<unknown>"),
+                        end: .init(line: 1, column: 3, offset: 2, file: "<unknown>")
+                    )
+                )
+            ]
+        )
+        XCTAssertEqual(
+            try Tokenizer.tokenize(" ... ").tokens,
+            [
+                .init(
+                    kind: .terminal(.ellipsis),
+                    range: .init(
+                        start: .init(line: 1, column: 2, offset: 1, file: "<unknown>"),
+                        end: .init(line: 1, column: 4, offset: 3, file: "<unknown>")
+                    )
+                )
+            ]
+        )
     }
 
     func test_dot() throws {
 
-        XCTAssertEqual(try Tokenizer.tokenize(".").tokens, [.terminal(.dot)])
-        XCTAssertEqual(try Tokenizer.tokenize(" . ").tokens, [.terminal(.dot)])
+        XCTAssertEqual(try Tokenizer.tokenize(".").tokens.map(\.kind), [.terminal(.dot)])
+        XCTAssertEqual(try Tokenizer.tokenize(" . ").tokens.map(\.kind), [.terminal(.dot)])
     }
 
     func test_dotDot() throws {
 
-        XCTAssertEqual(try Tokenizer.tokenize("..").tokens, [.terminal(.dot), .terminal(.dot)])
-        XCTAssertEqual(try Tokenizer.tokenize(" .. ").tokens, [.terminal(.dot), .terminal(.dot)])
+        XCTAssertEqual(try Tokenizer.tokenize("..").tokens.map(\.kind), [.terminal(.dot), .terminal(.dot)])
+        XCTAssertEqual(try Tokenizer.tokenize(" .. ").tokens.map(\.kind), [.terminal(.dot), .terminal(.dot)])
     }
 
     func test_dotDotDot() throws {
 
-        XCTAssertEqual(try Tokenizer.tokenize(".. .").tokens, [.terminal(.dot), .terminal(.dot), .terminal(.dot)])
-        XCTAssertEqual(try Tokenizer.tokenize(" . . . ").tokens, [.terminal(.dot), .terminal(.dot), .terminal(.dot)])
+        XCTAssertEqual(try Tokenizer.tokenize(".. .").tokens.map(\.kind), [.terminal(.dot), .terminal(.dot), .terminal(.dot)])
+        XCTAssertEqual(try Tokenizer.tokenize(" . . . ").tokens.map(\.kind), [.terminal(.dot), .terminal(.dot), .terminal(.dot)])
     }
 
     func test_integer() throws {
 
-        var result: TokenisationResult
+        var result: TokenizationResult
 
         result = try Tokenizer.tokenize("0 ")
-        XCTAssertEqual(result.tokens, [.integer])
+        XCTAssertEqual(result.tokens.map(\.kind), [.integer])
         XCTAssertEqual(result.integers, [0])
 
         result = try Tokenizer.tokenize("1\n")
-        XCTAssertEqual(result.tokens, [.integer])
+        XCTAssertEqual(result.tokens.map(\.kind), [.integer])
         XCTAssertEqual(result.integers, [1])
 
         result = try Tokenizer.tokenize("0xf")
-        XCTAssertEqual(result.tokens, [.integer])
+        XCTAssertEqual(result.tokens.map(\.kind), [.integer])
         XCTAssertEqual(result.integers, [0xf])
 
         result = try Tokenizer.tokenize("0XFF, 0XFF; 0XFF")
-        XCTAssertEqual(result.tokens, [.integer, .terminal(.comma), .integer, .terminal(.semicolon), .integer])
+        XCTAssertEqual(result.tokens.map(\.kind), [.integer, .terminal(.comma), .integer, .terminal(.semicolon), .integer])
         XCTAssertEqual(result.integers, [0xff, 0xff, 0xff])
 
         result = try Tokenizer.tokenize("-1, -1; -1")
-        XCTAssertEqual(result.tokens, [.integer, .terminal(.comma), .integer, .terminal(.semicolon), .integer])
+        XCTAssertEqual(result.tokens.map(\.kind), [.integer, .terminal(.comma), .integer, .terminal(.semicolon), .integer])
         XCTAssertEqual(result.integers, [-1, -1, -1])
     }
 
     func test_decimal() throws {
 
-        var result: TokenisationResult
+        var result: TokenizationResult
 
         result = try Tokenizer.tokenize("0.0 ")
-        XCTAssertEqual(result.tokens, [.decimal])
+        XCTAssertEqual(result.tokens.map(\.kind), [.decimal])
         XCTAssertEqual(result.decimals, [0.0])
 
         result = try Tokenizer.tokenize("0.1\n")
-        XCTAssertEqual(result.tokens, [.decimal])
+        XCTAssertEqual(result.tokens.map(\.kind), [.decimal])
         XCTAssertEqual(result.decimals, [0.1])
 
         result = try Tokenizer.tokenize("-1.0")
-        XCTAssertEqual(result.tokens, [.decimal])
+        XCTAssertEqual(result.tokens.map(\.kind), [.decimal])
         XCTAssertEqual(result.decimals, [-1.0])
 
         result = try Tokenizer.tokenize("1e+10")
-        XCTAssertEqual(result.tokens, [.decimal])
+        XCTAssertEqual(result.tokens.map(\.kind), [.decimal])
         XCTAssertEqual(result.decimals, [1e+10])
 
         result = try Tokenizer.tokenize("1E+10")
-        XCTAssertEqual(result.tokens, [.decimal])
+        XCTAssertEqual(result.tokens.map(\.kind), [.decimal])
         XCTAssertEqual(result.decimals, [1e+10])
 
         result = try Tokenizer.tokenize("1.5E+10, 1.5E+10; 1.5E+10")
-        XCTAssertEqual(result.tokens, [.decimal, .terminal(.comma), .decimal, .terminal(.semicolon), .decimal])
+        XCTAssertEqual(result.tokens.map(\.kind), [.decimal, .terminal(.comma), .decimal, .terminal(.semicolon), .decimal])
         XCTAssertEqual(result.decimals, [1.5e+10, 1.5e+10, 1.5e+10])
     }
 
     func test_identifier() throws {
 
-        var result: TokenisationResult
+        var result: TokenizationResult
 
         result = try Tokenizer.tokenize("abc ")
-        XCTAssertEqual(result.tokens, [.identifier])
+        XCTAssertEqual(result.tokens.map(\.kind), [.identifier])
         XCTAssertEqual(result.identifiers, ["abc"])
 
         result = try Tokenizer.tokenize("abc...")
-        XCTAssertEqual(result.tokens, [.identifier, .terminal(.ellipsis)])
+        XCTAssertEqual(result.tokens.map(\.kind), [.identifier, .terminal(.ellipsis)])
         XCTAssertEqual(result.identifiers, ["abc"])
 
         result = try Tokenizer.tokenize("ABC1\n")
-        XCTAssertEqual(result.tokens, [.identifier])
+        XCTAssertEqual(result.tokens.map(\.kind), [.identifier])
         XCTAssertEqual(result.identifiers, ["ABC1"])
 
         result = try Tokenizer.tokenize("-abc1")
-        XCTAssertEqual(result.tokens, [.identifier])
+        XCTAssertEqual(result.tokens.map(\.kind), [.identifier])
         XCTAssertEqual(result.identifiers, ["-abc1"])
 
         result = try Tokenizer.tokenize("_ab-1c, _ab-1c; _ab-1c")
-        XCTAssertEqual(result.tokens, [.identifier, .terminal(.comma), .identifier, .terminal(.semicolon), .identifier])
+        XCTAssertEqual(result.tokens.map(\.kind), [.identifier, .terminal(.comma), .identifier, .terminal(.semicolon), .identifier])
         XCTAssertEqual(result.identifiers, ["_ab-1c", "_ab-1c", "_ab-1c"])
     }
 
@@ -119,6 +140,24 @@ final class TokenizerTests: XCTestCase {
         **/
         """)
 
-        XCTAssertEqual(result.tokens, [.comment("SingleLine"), .multilineComment("\nMultiLine\n*")])
+        XCTAssertEqual(
+            result.tokens,
+            [
+                .init(
+                    kind: .comment("SingleLine"),
+                    range: .init(
+                        start: .init(line: 1, column: 1, offset: 0, file: "<unknown>"),
+                        end: .init(line: 1, column: 14, offset: 13, file: "<unknown>")
+                    )
+                ),
+                .init(
+                    kind: .multilineComment("\nMultiLine\n*"),
+                    range: .init(
+                        start: .init(line: 2, column: 1, offset: 14, file: "<unknown>"),
+                        end: .init(line: 4, column: 3, offset: 29, file: "<unknown>")
+                    )
+                )
+            ]
+        )
     }
 }


### PR DESCRIPTION
Now the output for the WebGL spec looks like

```
Encountered enexpected token Token(kind: .terminal(typedef), range: (519:5,519:12)), but expected .terminal(})
```

which precisely points at line 519 in it, while previously it was unclear where exactly the failing token was located.

To implement this I changed `enum Token` to `struct Token`, moving cases of the enum to `enum Kind` within the new `Token` struct.