### PR TITLE
Switch to Xcode 13.2.1 in `swift.yml` workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,13 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
-      with:
-        swift-version: "5.3.0"
-    - name: Xcode 12.3
-      run: sudo xcode-select -s /Applications/Xcode_12.3.app/Contents/Developer
+    - name: Select Xcode 13.2.1
+      run: sudo xcode-select -s /Applications/Xcode_13.2.1.app/Contents/Developer
     - name: Xcode version check
       run: xcodebuild -version
     - name: Check version

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,17 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "e1465042f195f374b94f915ba8ca49de24300a0d",
+          "version": "1.0.2"
         }
       },
       {
         "package": "swift-format",
         "repositoryURL": "https://github.com/apple/swift-format.git",
         "state": {
-          "branch": "swift-5.3-branch",
-          "revision": "12089179aa1668a2478b2b2111d98fa37f3531e3",
-          "version": null
+          "branch": null,
+          "revision": "f872223e16742fd97fabd319fbf4a939230cc796",
+          "version": "0.50500.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
-          "version": "0.50300.0"
+          "revision": "75e60475d9d8fd5bbc16a12e0eaa2cb01b0c322e",
+          "version": "0.50500.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -8,14 +8,14 @@ let package = Package(
     platforms: [.macOS(.v10_14)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .executable(name: "webidl2swift", targets: ["webidl2swift", ]),
+        .executable(name: "webidl2swift", targets: ["webidl2swift"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser", from: "0.3.1"),
-        .package(name: "swift-format", url: "https://github.com/apple/swift-format.git", .branch("swift-5.3-branch")),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .upToNextMinor(from: "0.50300.0")),
+        .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser", from: "1.0.1"),
+        .package(name: "swift-format", url: "https://github.com/apple/swift-format.git", .upToNextMinor(from: "0.50500.0")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .upToNextMinor(from: "0.50500.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -29,14 +29,14 @@ let package = Package(
                 .unsafeFlags([
                     // Fix for missing rpath for lib_InternalSwiftSyntaxParser.dylib when building from within Xcode.
                     // lib_InternalSwiftSyntaxParser.dylib is linked by SwiftSyntax.
-                    "-Xlinker", "-rpath", "-Xlinker", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/"
-                ])
+                    "-Xlinker", "-rpath", "-Xlinker", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/",
+                ]),
             ]
         ),
         .target(
             name: "WebIDL",
             dependencies: [
-                "SwiftSyntax"
+                "SwiftSyntax",
             ],
             path: "Sources/WebIDL"
         ),
@@ -54,8 +54,8 @@ let package = Package(
                 .unsafeFlags([
                     // Fix for missing rpath for lib_InternalSwiftSyntaxParser.dylib when building from within Xcode.
                     // lib_InternalSwiftSyntaxParser.dylib is linked by SwiftSyntax.
-                    "-Xlinker", "-rpath", "-Xlinker", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/"
-                ])
+                    "-Xlinker", "-rpath", "-Xlinker", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/",
+                ]),
             ]
         ),
         .testTarget(
@@ -67,8 +67,8 @@ let package = Package(
                 .unsafeFlags([
                     // Fix for missing rpath for lib_InternalSwiftSyntaxParser.dylib when building from within Xcode.
                     // lib_InternalSwiftSyntaxParser.dylib is linked by SwiftSyntax.
-                    "-Xlinker", "-rpath", "-Xlinker", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/"
-                ])
+                    "-Xlinker", "-rpath", "-Xlinker", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/",
+                ]),
             ]
         ),
     ]

--- a/Tests/webidl2swiftTests/webidl2swiftTests.swift
+++ b/Tests/webidl2swiftTests/webidl2swiftTests.swift
@@ -5,7 +5,7 @@
 import XCTest
 import ArgumentParser
 import Commands
-@testable import webidl2swift
+@testable import Commands
 
 // swiftlint:disable:next type_name
 final class webidl2swiftTests: XCTestCase {


### PR DESCRIPTION
Currently selected version of Xcode makes PRs fail on CI. Let's switch to the latest one. I've also updated SwiftPM dependencies for compatibility with Xcode 13.